### PR TITLE
Use fallback image(s) when song jacket cannot be found

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 const DATA_URL = 'https://cors-anywhere.herokuapp.com/https://maimai.sega.com/data/DXsongs.json'; //'./DXsongs.json';
 const IMG_URL = 'https://maimai.sega.com/storage/DX_jacket/';
+const IMG_URL_FALLBACK = 'https://maimai.sega.jp/storage/DX_jacket/';
 const CATS = {
 	'POPSアニメ': 'Pops & Anime',
 	'niconicoボーカロイド': 'Niconico & Vocaloid',
@@ -125,6 +126,7 @@ const render_songs = async data => {
 
 		let img = document.createElement('img');
 		img.alt = '';
+		img.title = s.title;
 		if ("IntersectionObserver" in window && observer) {
 			img.dataset.src = `${IMG_URL}${s.image_url}`;
 			img.src = "data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E .e %7B font-size: 20px; %7D %3C/style%3E%3Ctext x='40' y='55' class='e'%3E⌛%3C/text%3E%3C/svg%3E";
@@ -132,6 +134,10 @@ const render_songs = async data => {
 		} else {
 			img.src = `${IMG_URL}${s.image_url}`;
 		}
+		img.onerror = (event) => {
+			img.onerror = (event) => { img.onerror = null; img.src = "でらっくま.png" };
+			img.src = `${IMG_URL_FALLBACK}${s.image_url}`;
+		};
 		song.appendChild(img);
 
 		let meta = document.createElement('div');


### PR DESCRIPTION
# Introduction
The SEGA song list has a weird quirk where a few songs (mainly in the Vocaloid update) do not actually have jackets in the URL passed to `storage/DX_jacket`. However, they still do on the JP maimai DX website.

# Changes
- If a song jacket 404s, try to fall back on using the JP maimai DX's assets instead. If that doesn't work, use `でらっくま.png`.
- Add a title to the song jacket so you can see the song name upon hover.

# Preview
*These songs had a 404 issue*
![chrome_12-03-23-48-52_Fib7HPvqD5](https://user-images.githubusercontent.com/9653765/101137634-ff1e4200-35c3-11eb-97f6-d83de80fde61.png)

*Last Fallback*
![chrome_12-03-23-46-56_oZmGjyNHG3](https://user-images.githubusercontent.com/9653765/101137619-fa598e00-35c3-11eb-8fda-e640baeef752.png)

*Song Title*
![recording_12-03-23-51-10_6CcAGHJuC8](https://user-images.githubusercontent.com/9653765/101137663-08a7aa00-35c4-11eb-92c7-60dad4483857.gif)